### PR TITLE
[FIX-1] Fix device GetNextEvent()

### DIFF
--- a/pkg/device/device.go
+++ b/pkg/device/device.go
@@ -124,7 +124,7 @@ func (d deviceImpl) GetNumber() int {
 	return d.deviceNumber
 }
 
-func (d deviceImpl) GetNextEvent() *events.DevFreeEvent {
+func (d *deviceImpl) GetNextEvent() *events.DevFreeEvent {
 	event := d.nextEvent
 	if event != nil {
 		d.nextEvent = nil


### PR DESCRIPTION
# Описание

`GenNextEvent()` принимал `Device` по значению, а надо по указателю